### PR TITLE
Formal code formatting and documentation improvements

### DIFF
--- a/benches/bench_balance.rs
+++ b/benches/bench_balance.rs
@@ -1,28 +1,36 @@
 #![feature(test)]
-extern crate test;
 extern crate drpc;
+extern crate test;
 
+use drpc::balance::{LoadBalance, LoadBalanceType, RpcClient};
+use drpc::client::Client;
 use std::mem::MaybeUninit;
 use std::thread::sleep;
 use std::time::Duration;
-use drpc::balance::{LoadBalance, LoadBalanceType, RpcClient};
-use drpc::client::Client;
 
-struct C{
-   pub addr:String,
+struct C {
+    pub addr: String,
 }
-impl RpcClient for C{
+impl RpcClient for C {
     fn addr(&self) -> &str {
         &self.addr
     }
 }
 #[bench]
 fn bench_balance(b: &mut test::Bencher) {
-    let mut load =LoadBalance::<C>::new();
-    load.put(C{addr:"127.0.0.1:13000".to_string()});
-    load.put(C{addr:"127.0.0.1:13001".to_string()});
-    load.put(C{addr:"127.0.0.1:13002".to_string()});
-    load.put(C{addr:"127.0.0.1:13003".to_string()});
+    let mut load = LoadBalance::<C>::new();
+    load.put(C {
+        addr: "127.0.0.1:13000".to_string(),
+    });
+    load.put(C {
+        addr: "127.0.0.1:13001".to_string(),
+    });
+    load.put(C {
+        addr: "127.0.0.1:13002".to_string(),
+    });
+    load.put(C {
+        addr: "127.0.0.1:13003".to_string(),
+    });
     b.iter(|| {
         load.do_balance(LoadBalanceType::Round, "");
     });

--- a/benches/bench_bincode.rs
+++ b/benches/bench_bincode.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
-extern crate test;
 extern crate serde;
+extern crate test;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct A {

--- a/benches/bench_serde.rs
+++ b/benches/bench_serde.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
-extern crate test;
 extern crate serde;
 extern crate serde_json;
-use serde::{Serialize, Deserialize};
+extern crate test;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct A {

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -7,21 +7,21 @@ extern crate test;
 #[macro_use]
 extern crate tokio;
 
+use drpc::client::Client;
+use drpc::codec::BinCodec;
+use drpc::server::Server;
 use std::sync::mpsc::channel;
 use std::thread::sleep;
 use std::time::Duration;
 use test::Bencher;
-use drpc::client::Client;
-use drpc::codec::BinCodec;
-use drpc::server::Server;
-
 
 #[cfg(test)]
 #[bench]
 fn latency(bencher: &mut Bencher) {
     let rt_server = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build().unwrap();
+        .build()
+        .unwrap();
     rt_server.spawn(async {
         pub async fn handle(req: i32) -> dark_std::errors::Result<i32> {
             Ok(req + 1)
@@ -32,10 +32,11 @@ fn latency(bencher: &mut Bencher) {
         println!("rpc served");
     });
     let (s, r) = channel();
-    std::thread::spawn(move ||{
+    std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .build().unwrap();
+            .build()
+            .unwrap();
         rt.block_on(async {
             sleep(Duration::from_secs(1));
             let mut c = Client::<BinCodec>::dial("127.0.0.1:10000").await.unwrap();

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,10 +1,10 @@
-use std::process::exit;
-use std::time::Duration;
-use fast_log::config::Config;
-use tokio::time::sleep;
 use drpc::client::Client;
 use drpc::codec::BinCodec;
 use drpc::server::Server;
+use fast_log::config::Config;
+use std::process::exit;
+use std::time::Duration;
+use tokio::time::sleep;
 
 pub async fn handle(req: i32) -> drpc::Result<i32> {
     Ok(req + 1)

--- a/example/src/main_bson.rs
+++ b/example/src/main_bson.rs
@@ -1,12 +1,12 @@
-use std::process::exit;
-use std::time::Duration;
-use fast_log::config::Config;
-use tokio::time::sleep;
-use serde::{Serialize, Deserialize};
-use serde::de::DeserializeOwned;
 use drpc::client::Client;
 use drpc::codec::Codec;
 use drpc::server::Server;
+use fast_log::config::Config;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::process::exit;
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DTO {
@@ -27,10 +27,16 @@ async fn main() {
         sleep(Duration::from_secs(1)).await;
         let c = Client::<BsonCodec>::dial("127.0.0.1:10000").await.unwrap();
         println!("dial success");
-        let resp: DTO = c.call("handle", DTO {
-            name: "joe".to_string(),
-            age: 18,
-        }).await.unwrap();
+        let resp: DTO = c
+            .call(
+                "handle",
+                DTO {
+                    name: "joe".to_string(),
+                    age: 18,
+                },
+            )
+            .await
+            .unwrap();
         println!("resp=>>>>>>>>>>>>>> :{:?}", resp);
         exit(0);
     });
@@ -39,15 +45,15 @@ async fn main() {
     s.serve("0.0.0.0:10000").await;
 }
 
-#[derive(Clone,Debug,Default)]
-pub struct BsonCodec{}
+#[derive(Clone, Debug, Default)]
+pub struct BsonCodec {}
 
-impl Codec for BsonCodec{
+impl Codec for BsonCodec {
     fn encode<T: Serialize>(&self, arg: T) -> std::result::Result<Vec<u8>, drpc::Error> {
-        bson::to_vec(&arg).map_err(|e|drpc::err!("{}",e.to_string()))
+        bson::to_vec(&arg).map_err(|e| drpc::err!("{}", e.to_string()))
     }
 
     fn decode<T: DeserializeOwned>(&self, arg: &[u8]) -> std::result::Result<T, drpc::Error> {
-        bson::from_slice(arg).map_err(|e|drpc::err!("{}",e.to_string()))
+        bson::from_slice(arg).map_err(|e| drpc::err!("{}", e.to_string()))
     }
 }

--- a/example/src/main_json.rs
+++ b/example/src/main_json.rs
@@ -1,11 +1,11 @@
+use drpc::client::Client;
+use drpc::codec::JsonCodec;
+use drpc::server::Server;
+use fast_log::config::Config;
+use serde::{Deserialize, Serialize};
 use std::process::exit;
 use std::time::Duration;
-use fast_log::config::Config;
 use tokio::time::sleep;
-use serde::{Serialize, Deserialize};
-use drpc::client::Client;
-use drpc::codec::{JsonCodec};
-use drpc::server::Server;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DTO {
@@ -26,10 +26,16 @@ async fn main() {
         sleep(Duration::from_secs(1)).await;
         let c = Client::<JsonCodec>::dial("127.0.0.1:10000").await.unwrap();
         println!("dial success");
-        let resp: DTO = c.call("handle", DTO {
-            name: "joe".to_string(),
-            age: 18,
-        }).await.unwrap();
+        let resp: DTO = c
+            .call(
+                "handle",
+                DTO {
+                    name: "joe".to_string(),
+                    age: 18,
+                },
+            )
+            .await
+            .unwrap();
         println!("resp=>>>>>>>>>>>>>> :{:?}", resp);
         exit(0);
     });

--- a/example/src/main_set_frame_size.rs
+++ b/example/src/main_set_frame_size.rs
@@ -1,10 +1,10 @@
-use std::process::exit;
-use std::time::Duration;
-use fast_log::config::Config;
-use tokio::time::sleep;
 use drpc::client::Client;
 use drpc::codec::BinCodec;
 use drpc::server::Server;
+use fast_log::config::Config;
+use std::process::exit;
+use std::time::Duration;
+use tokio::time::sleep;
 
 pub async fn handle(req: String) -> drpc::Result<String> {
     Ok(req)

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -14,19 +14,15 @@ pub struct JsonCodec {}
 impl Codec for JsonCodec {
     fn encode<T: Serialize>(&self, arg: T) -> Result<Vec<u8>, Error> {
         match serde_json::to_vec(&arg) {
-            Ok(ok) => { Ok(ok) }
-            Err(e) => { Err(err!("{}",e)) }
+            Ok(ok) => Ok(ok),
+            Err(e) => Err(err!("{}", e)),
         }
     }
 
     fn decode<T: DeserializeOwned>(&self, arg: &[u8]) -> Result<T, Error> {
         match serde_json::from_slice(arg) {
-            Ok(v) => {
-                Ok(v)
-            }
-            Err(e) => {
-                Err(err!("{}",e))
-            }
+            Ok(v) => Ok(v),
+            Err(e) => Err(err!("{}", e)),
         }
     }
 }
@@ -37,15 +33,15 @@ pub struct BinCodec {}
 impl Codec for BinCodec {
     fn encode<T: Serialize>(&self, arg: T) -> Result<Vec<u8>, Error> {
         match bincode::serialize(&arg) {
-            Ok(ok) => { Ok(ok) }
-            Err(e) => { Err(err!("{}",e)) }
+            Ok(ok) => Ok(ok),
+            Err(e) => Err(err!("{}", e)),
         }
     }
 
     fn decode<T: DeserializeOwned>(&self, arg: &[u8]) -> Result<T, Error> {
         match bincode::deserialize(arg) {
-            Ok(ok) => { Ok(ok) }
-            Err(e) => { Err(err!("{}",e)) }
+            Ok(ok) => Ok(ok),
+            Err(e) => Err(err!("{}", e)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@ extern crate async_trait;
 extern crate log;
 extern crate rand;
 
-pub mod codec;
-pub mod stub;
-pub mod client;
-pub mod server;
-pub mod frame;
 pub mod balance;
 pub mod balance_manager;
+pub mod client;
+pub mod codec;
+pub mod frame;
+pub mod server;
+pub mod stub;
 pub use balance_manager::*;
 pub use dark_std::errors::Error;
 pub use dark_std::errors::Result;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,14 +1,14 @@
-use std::future::Future;
-use tokio::net::{TcpListener};
 use crate::codec::{BinCodec, Codec};
 use crate::stub::ServerStub;
-use std::sync::Arc;
+use dark_std::errors::Result;
 use dark_std::sync::SyncHashMap;
+use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use dark_std::errors::Result;
-use futures::future::BoxFuture;
+use std::future::Future;
+use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpListener;
 
 pub struct Server<C: Codec> {
     pub handles: SyncHashMap<String, Box<dyn Stub<C>>>,
@@ -37,9 +37,12 @@ impl Default for Server<BinCodec> {
 }
 
 impl<C: Codec> Server<C> {
-    ///call server method
+    /// Call the server method
     #[inline]
-    pub async fn call<S>(&self, stream: S) where S: AsyncRead + AsyncWrite + Unpin {
+    pub async fn call<S>(&self, stream: S)
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
         self.stub.call(&self.handles, &self.codec, stream).await;
     }
 }
@@ -72,19 +75,23 @@ pub trait Handler<C: 'static + Codec>: Stub<C> + Sync + Send {
 
 impl<C: Codec + 'static, H: Handler<C>> Stub<C> for H {
     fn accept(&self, arg: &[u8], codec: &C) -> BoxFuture<Result<Vec<u8>>> {
-        <H as Handler::<C>>::accept(self, arg, codec)
+        <H as Handler<C>>::accept(self, arg, codec)
     }
 }
 
 pub struct HandleFn<Req: DeserializeOwned, Resp: Serialize> {
     pub f: Box<dyn Fn(Req) -> BoxFuture<'static, Result<Resp>>>,
 }
-//it's safety
+
+// It's safe
 unsafe impl<Req: DeserializeOwned, Resp: Serialize> Sync for HandleFn<Req, Resp> {}
-//it's safety
+
+// It's safe
 unsafe impl<Req: DeserializeOwned, Resp: Serialize> Send for HandleFn<Req, Resp> {}
 
-impl<C: Codec + 'static, Req: DeserializeOwned + Send, Resp: Serialize> Handler<C> for HandleFn<Req, Resp> {
+impl<C: Codec + 'static, Req: DeserializeOwned + Send, Resp: Serialize> Handler<C>
+    for HandleFn<Req, Resp>
+{
     type Req = Req;
     type Resp = Resp;
 
@@ -94,50 +101,78 @@ impl<C: Codec + 'static, Req: DeserializeOwned + Send, Resp: Serialize> Handler<
 }
 
 impl<Req: DeserializeOwned, Resp: Serialize> HandleFn<Req, Resp> {
-    pub fn new<F: 'static>(f: F) -> Self where F: Fn(Req) -> BoxFuture<'static, Result<Resp>> {
-        Self {
-            f: Box::new(f),
-        }
+    pub fn new<F: 'static>(f: F) -> Self
+    where
+        F: Fn(Req) -> BoxFuture<'static, Result<Resp>>,
+    {
+        Self { f: Box::new(f) }
     }
 }
 
-
 impl<C: Codec + 'static> Server<C> {
-    ///register a handle to server
-    pub async fn register<H: 'static>(&mut self, name: &str, handle: H) where H: Stub<C> {
+    /// Register a handle into the server.
+    pub async fn register<H: 'static>(&mut self, name: &str, handle: H)
+    where
+        H: Stub<C>,
+    {
         self.handles.insert(name.to_owned(), Box::new(handle)).await;
     }
 
-    /// register a register_box_future into server
-    pub fn register_box_future<Req: DeserializeOwned + Send + 'static, Resp: Serialize + 'static, F: 'static>(&mut self, name: &str, f: F)
-        where F: Fn(Req) -> BoxFuture<'static, Result<Resp>> {
-        self.handles.insert_mut(name.to_owned(), Box::new(HandleFn::new(f)));
+    /// Register a `register_box_future` into the server.
+    pub fn register_box_future<
+        Req: DeserializeOwned + Send + 'static,
+        Resp: Serialize + 'static,
+        F: 'static,
+    >(
+        &mut self,
+        name: &str,
+        f: F,
+    ) where
+        F: Fn(Req) -> BoxFuture<'static, Result<Resp>>,
+    {
+        self.handles
+            .insert_mut(name.to_owned(), Box::new(HandleFn::new(f)));
     }
 
-    /// register a func into server
-    /// for example:
+    /// Register a callback into the server.
+    /// For example:
     /// ```
     /// use drpc::server::{Server};
     /// use dark_std::errors::Result;
     /// let mut s = Server::default();
-    /// async fn handle(req: i32) -> dark_std::errors::Result<i32> { return Ok(req + 1); }
     ///
+    /// async fn handle(req: i32) -> dark_std::errors::Result<i32> { return Ok(req + 1); }
     ///     s.register_fn("handle", handle);
-    ///     //way 2
+    ///     // way 2
     ///     s.register_fn("handle_fn2", |arg:i32| async move {
     ///         Ok(1)
     ///     });
     /// ```
-    pub fn register_fn<Req: DeserializeOwned + Send + 'static, Resp: Serialize + 'static, Out: 'static, F: 'static>(&mut self, name: &str, f: F)
-        where
-            Out: Future<Output=Result<Resp>> + Send,
-            F: Fn(Req) -> Out {
-        self.handles.insert_mut(name.to_owned(), Box::new(HandleFn::new(move |req: Req| -> BoxFuture<'static, Result<Resp>>{
-            Box::pin((f)(req))
-        })));
+    pub fn register_fn<
+        Req: DeserializeOwned + Send + 'static,
+        Resp: Serialize + 'static,
+        Out: 'static,
+        F: 'static,
+    >(
+        &mut self,
+        name: &str,
+        f: F,
+    ) where
+        Out: Future<Output = Result<Resp>> + Send,
+        F: Fn(Req) -> Out,
+    {
+        self.handles.insert_mut(
+            name.to_owned(),
+            Box::new(HandleFn::new(
+                move |req: Req| -> BoxFuture<'static, Result<Resp>> { Box::pin((f)(req)) },
+            )),
+        );
     }
 
-    pub async fn serve<A>(self, addr: A) where A: tokio::net::ToSocketAddrs {
+    pub async fn serve<A>(self, addr: A)
+    where
+        A: tokio::net::ToSocketAddrs,
+    {
         let listener = TcpListener::bind(addr).await.unwrap();
         println!(
             "Starting tcp server on {:?}",


### PR DESCRIPTION
Since I didn't find a code style for the project.
This PR applies _[The formal Rust code formatting](https://github.com/rust-lang/rustfmt)_ via `cargo fmt --all` and improves the code documentation.
It also sorts some imports across the library as well as prefixes some unused parameters in the code.
